### PR TITLE
refactor: Align Rapidity with JuLs and add raw speed display

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,9 @@ This document outlines future development tasks and ideas for the chaotic idle g
 
 ## II. Speed of Light Theme Integration
 
-*   [x] Define core thematic elements: JuLs (energy), Rapidity (φ), Ship Speed (v/c).
+*   [x] Define core thematic elements: JuLs (energy, 1 JuL = 1 unit of Rapidity φ), Ship Speed (v/c and raw v).
+*   [x] Ensure Tier 1 ("JuL Harvester") directly produces JuLs. (Worker confirmed it was already correct, so task is complete).
+*   [x] Display raw ship speed (v) in m/s.
 *   [x] Rename existing generators and resources to fit the new theme.
 *   [x] Implement Rapidity calculation and display.
 *   [ ] Future: Explore mechanics related to relativistic effects (time dilation, length contraction) as potential prestige layers or boosts.

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
             <p>Base Currency (Objects): <span id="base-currency-count">0</span></p>
             <p>Current Rapidity (φ): <span id="current-rapidity">0.00</span></p>
             <p>Ship Speed (v/c): <span id="ship-speed-vc">0.00</span>%</p>
+            <p>Ship Speed (v): <span id="ship-speed-raw">0.00</span> m/s</p>
             
             <div id="purchase-multipliers" style="margin-top: 15px;">
                 <span>Buy Amount:</span>

--- a/script.js
+++ b/script.js
@@ -120,6 +120,8 @@ for (let i = 0; i < letters.length; i++) {
 // This will generate: '', K, M, B, T, aa, ab, ..., az, ba, bb, ..., bz, ..., za, ..., zz
 // Total of 5 + 26*26 = 5 + 676 = 681 suffixes, handling up to 1000^680
 
+const SPEED_OF_LIGHT_MPS = new Decimal(299792458); // meters per second
+
 function formatNumber(num) {
     if (!(num instanceof Decimal)) {
         // Attempt to convert non-Decimal inputs, log error if conversion fails or results in NaN
@@ -570,8 +572,8 @@ function updateUI() {
     // Calculate and Display Rapidity & Ship Speed
     const rapidityElement = document.getElementById('current-rapidity');
     const speedElement = document.getElementById('ship-speed-vc');
-    const SCALING_FACTOR_JULS_TO_RAPIDITY = 1000;
-    let currentRapidity = gameData.baseCurrency.div(SCALING_FACTOR_JULS_TO_RAPIDITY);
+    // Rapidity (φ) is now directly equal to the total JuLs.
+    let currentRapidity = gameData.baseCurrency;
 
     if (rapidityElement) {
         rapidityElement.textContent = formatNumber(currentRapidity);
@@ -602,6 +604,19 @@ function updateUI() {
     } else {
         console.error("updateUI: ship-speed-vc element NOT FOUND");
     }
+
+    // Calculate and Display Raw Ship Speed (v)
+    const rawSpeedElement = document.getElementById('ship-speed-raw');
+    if (rawSpeedElement) {
+        // vcRatio is already calculated from Math.tanh(numericRapidity)
+        // Ensure vcRatio is a Decimal for multiplication with SPEED_OF_LIGHT_MPS
+        let vcRatioDecimal = new Decimal(vcRatio); // vcRatio is a JS number from Math.tanh
+        let rawSpeed = SPEED_OF_LIGHT_MPS.mul(vcRatioDecimal);
+        rawSpeedElement.textContent = formatNumber(rawSpeed); // formatNumber handles the number, " m/s" is in HTML
+    } else {
+        console.error("updateUI: ship-speed-raw element NOT FOUND");
+    }
+
 
     gameData.generators.forEach(generator => {
         const tierElement = document.getElementById(`generator-tier-${generator.id}`);


### PR DESCRIPTION
This commit refines the "Speed of Light" theme implementation based on your feedback.

Key changes:

1.  **Rapidity Calculation Adjusted:**
    *   Rapidity (φ) is now directly equivalent to the total number of JuLs (1 JuL = 1 unit of Rapidity). The previous scaling factor has been removed.

2.  **Raw Ship Speed (v) Display:**
    *   Added a new UI element to display the ship's speed in raw m/s.
    *   This is calculated as `v = c * tanh(Rapidity)`.

3.  **Tier 1 Production Verified:**
    *   Confirmed that the Tier 1 generator ("JuL Harvester") was already correctly configured to produce JuLs (baseCurrency).

4.  **TODO.md Updated:**
    *   Reflected the 1:1 JuL-to-Rapidity definition.
    *   Marked tasks for verifying Tier 1 production and adding raw speed display as complete.

These changes ensure a more accurate and complete realization of the intended relativistic theme.