### PR TITLE
fix: Prevent buy button failure from corrupt saved multiplier

### DIFF
--- a/script.js
+++ b/script.js
@@ -227,7 +227,27 @@ function loadGame() {
         // Load simple properties
         gameData.baseCurrencyName = parsedData.baseCurrencyName || gameData.baseCurrencyName;
         gameData.debugFreePurchases = typeof parsedData.debugFreePurchases === 'boolean' ? parsedData.debugFreePurchases : gameData.debugFreePurchases;
-        gameData.currentBuyMultiplier = parsedData.currentBuyMultiplier || gameData.currentBuyMultiplier;
+        
+        // Sanitize and load currentBuyMultiplier
+        if (parsedData.hasOwnProperty('currentBuyMultiplier')) {
+            const loadedMultiplier = parsedData.currentBuyMultiplier;
+            if (loadedMultiplier === 'MAX') {
+                gameData.currentBuyMultiplier = 'MAX';
+            } else {
+                const numericMultiplier = parseInt(loadedMultiplier, 10);
+                if (!isNaN(numericMultiplier) && [1, 10, 100].includes(numericMultiplier)) {
+                    gameData.currentBuyMultiplier = numericMultiplier;
+                } else {
+                    // Default to 1 if loaded value is invalid or not one of the allowed numbers
+                    gameData.currentBuyMultiplier = 1; 
+                    console.warn(`Invalid or unsupported currentBuyMultiplier ("${loadedMultiplier}") loaded from save. Defaulting to 1.`);
+                }
+            }
+        } else {
+            // If not present in save, it will retain its default value from gameData initialization (which is 1)
+            // Or, explicitly set it to default if concerned about initial gameData state:
+            // gameData.currentBuyMultiplier = 1; 
+        }
         // gameData.lastUpdate = parsedData.lastUpdate || Date.now(); // Will be overwritten later
 
         // Load Decimal properties


### PR DESCRIPTION
Corrects an issue where buy buttons (x1, x10, x100) could fail silently if `currentBuyMultiplier` was loaded from localStorage with a corrupted non-numeric string value.

The `loadGame()` function now sanitizes the `currentBuyMultiplier` value. If the loaded value is not 'MAX' or one of the valid numbers (1, 10, 100), it defaults to 1 and logs a warning. This ensures `buyGenerator` always receives a valid multiplier, preventing it from creating a `Decimal NaN` for the purchase quantity which led to the silent failure.