### PR TITLE
Fix: Use Decimal.equals(Decimal.Infinity) for infinity check

### DIFF
--- a/script.js
+++ b/script.js
@@ -691,7 +691,8 @@ function buyGenerator(generatorId) {
     
     // Handle cases where numToBuy (derived from 'MAX' or specific number) might be infinite
     // This is the corrected line, using numToBuy which is guaranteed to be a Decimal.
-    if (numToBuy.isInfinite()) { 
+    // Changed to use .equals() method for checking against Decimal.Infinity and Decimal.NegativeInfinity
+    if (numToBuy.equals(Decimal.Infinity) || numToBuy.equals(Decimal.NegativeInfinity)) {
         if (gameData.debugFreePurchases) {
             numToBuy = new Decimal(1000); // Cap for debug free purchases if calculated max is infinite
             console.log("Debug Free Purchases ON: Max buy is infinite, capping to 1000.");


### PR DESCRIPTION
Replaces the use of `numToBuy.isInfinite()` with
`numToBuy.equals(Decimal.Infinity) || numToBuy.equals(Decimal.NegativeInfinity)` in the `buyGenerator` function.

This workaround addresses a TypeError where `.isInfinite()` was not found on the Decimal object's prototype in your environment. The `.equals()` method provides a more robust way to check for infinite values, assuming `Decimal.Infinity` and `Decimal.NegativeInfinity` properties are available.